### PR TITLE
Update ServiceInfo Address to be compatible with Zeroconf 0.28.5

### DIFF
--- a/pysonofflanr3/client.py
+++ b/pysonofflanr3/client.py
@@ -115,7 +115,7 @@ class SonoffLANModeClient:
         if self.my_service_name is None:
 
             info = zeroconf.get_service_info(type, name)
-            found_ip = utils.parseAddress(info.address)
+            found_ip = utils.parseAddress(info.addresses[0])
 
             if self.device_id is not None:
 
@@ -162,7 +162,7 @@ class SonoffLANModeClient:
             return
 
         info = zeroconf.get_service_info(type, name)
-        found_ip = utils.parseAddress(info.address)
+        found_ip = utils.parseAddress(info.addresses[0])
         self.set_url(found_ip, str(info.port))
 
         # Useful optimsation for 0.24.1 onwards (fixed in 0.24.5 though)

--- a/pysonofflanr3/discover.py
+++ b/pysonofflanr3/discover.py
@@ -37,7 +37,7 @@ class MyListener:
         info = zeroconf.get_service_info(type, name)
         self.logger.debug(info)
         device = info.properties[b"id"].decode("ascii")
-        ip = utils.parseAddress(info.address) + ":" + str(info.port)
+        ip = utils.parseAddress(info.addresses[0]) + ":" + str(info.port)
 
         self.logger.info(
             "Found Sonoff LAN Mode device %s at socket %s" % (device, ip)


### PR DESCRIPTION
ServiceInfo changed the property Address from str to list. This is a patch to make pysonofflan compatible again.